### PR TITLE
Auto close response body when body length is 0

### DIFF
--- a/service/route.go
+++ b/service/route.go
@@ -3,6 +3,8 @@ package service
 import (
 	"fmt"
 	"os"
+	"io"
+	"io/ioutil"
 	"path/filepath"
 
 	"github.com/Hatch1fy/errors"
@@ -133,6 +135,11 @@ func (r *Route) serveHTTP(ctx *httpserve.Context) (res httpserve.Response) {
 		err = fmt.Errorf("Error serving %s: %v", key, err)
 		return httpserve.NewTextResponse(400, []byte(err.Error()))
 	}
+
+        b, _ := io.Copy(ioutil.Discard, ctx.Request.Body)
+        if b == 0 {
+            defer ctx.Request.Body.Close()
+        }
 
 	return
 }

--- a/service/route.go
+++ b/service/route.go
@@ -3,9 +3,8 @@ package service
 import (
 	"fmt"
 	"os"
-	"io"
-	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/Hatch1fy/errors"
 	"github.com/Hatch1fy/fileserver"
@@ -136,10 +135,12 @@ func (r *Route) serveHTTP(ctx *httpserve.Context) (res httpserve.Response) {
 		return httpserve.NewTextResponse(400, []byte(err.Error()))
 	}
 
-        b, _ := io.Copy(ioutil.Discard, ctx.Request.Body)
-        if b == 0 {
-            defer ctx.Request.Body.Close()
-        }
+	switch strings.ToLower(ctx.Request.Method) {
+	case "get", "delete":
+		defer ctx.Request.Body.Close()
+
+	default:
+	}
 
 	return
 }


### PR DESCRIPTION
We don't have data to read, so we likely won't bind the json.

This prevents the need to defer close all requests in get/remove scenarios without body content