### PR TITLE
Stop logging panics to a file

### DIFF
--- a/panicLog.go
+++ b/panicLog.go
@@ -2,43 +2,24 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"os"
+	"github.com/hatchify/scribe"
 	"runtime/debug"
-	"sync"
 )
 
 func newPanicLog() (pp *panicLog, err error) {
 	var p panicLog
-	if p.f, err = os.OpenFile("./panics.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0744); err != nil {
-		return
-	}
-
+	stdout := scribe.NewStdout()
+	p.f = scribe.NewWithWriter(stdout, ":: panic ::")
 	pp = &p
 	return
 }
 
 type panicLog struct {
-	mu sync.Mutex
-	f  *os.File
+	f  *scribe.Scribe
 }
 
 func (p *panicLog) Write(v interface{}) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	str := fmt.Sprintf("%v\n%s\n\n", v, string(debug.Stack()))
 
-	if _, err := p.f.WriteString(str); err != nil {
-		log.Println("Error writing string to panic log", err)
-		return
-	}
-
-	if err := p.f.Sync(); err != nil {
-		log.Println("Error writing string to panic log", err)
-		return
-	}
-}
-
-func (p *panicLog) Close() (err error) {
-	return p.f.Close()
+	p.f.Error(str)
 }

--- a/service.go
+++ b/service.go
@@ -483,6 +483,5 @@ func (s *Service) Close() (err error) {
 
 	var errs errors.ErrorList
 	errs.Push(s.Plugins.Close())
-	errs.Push(s.plog.Close())
 	return errs.Err()
 }


### PR DESCRIPTION
Panics currently go to a hardcoded `panics.log` file in the cwd. This makes it harder than it should be to integrate it with whatever's logging the rest of the app (likely stdout => journald in a systemd environment). Let's remove it, log panics to stdout so that it ships off with everything else. Alternately, we could make this configurable, but that would be more of an architectural change that would need to be discussed.